### PR TITLE
Update University of Washington group

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Andy Connolly
 
-  Members: Andrew Connolly, John Franklin Crenshaw, Dino Bektesevic, Colin Chandler, Sam Wyatt, Pedro Bernardinelli, Yuankun (David) Wang, Steven Stetzler, Jake Kurlander, Chester Li, Max West, Drew Oldag, Carl Christoffersen, Doug Branton
+  Members: Andrew Connolly, John Franklin Crenshaw, Dino Bektesevic, Colin Chandler, Sam Wyatt, Pedro Bernardinelli, Yuankun (David) Wang, Steven Stetzler, Jake Kurlander, Chester Li, Max West, Drew Oldag, Carl Christoffersen, Doug Branton, Karlo Mrakovcic
 
 
 **University of Wisconsin-Madison:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -344,6 +344,7 @@ groups:
       - Drew Oldag
       - Carl Christoffersen
       - Doug Branton
+      - Karlo Mrakovcic
   University of Wisconsin-Madison:
     contact: Keith Bechtol
     contribution: SIT-Com support
@@ -356,6 +357,6 @@ groups:
     contact: Steve Ritz
     contribution: SIT-Com support
     members:
-      - Steve Ritz 
+      - Steve Ritz
       - Adrian Shestakov
       - Duncan Wood


### PR DESCRIPTION
This PR adds Karlo Mrakovcic to the University of Washington contributing group.

Rendered version can be previewed [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-update-uw/index.html).