### PR TITLE
Add UC-Davis group

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -254,7 +254,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Tony Tyson
 
-  Members: Tony Tyson, Craig Lage, Dan Polin, Adam Snyder
+  Members: Tony Tyson, Craig Lage, Dan Polin, Adam Snyder, Erfan Nourbakhsh, Sam Schmidt
 
 
 **University of California, Santa Cruz:** *SIT-Com support*

--- a/groups.rst
+++ b/groups.rst
@@ -250,6 +250,13 @@ Institutional Contributions to Rubin Observatory Construction
   Members: Keith Bechtol, Peter Ferguson, Michael Martinez, Miranda Gorsuch
 
 
+**University of California, Davis:** *SIT-Com support*
+
+  Point of Contact: Tony Tyson
+
+  Members: Tony Tyson, Craig Lage, Dan Polin, Adam Snyder
+
+
 **University of California, Santa Cruz:** *SIT-Com support*
 
   Point of Contact: Steve Ritz

--- a/summary.yaml
+++ b/summary.yaml
@@ -353,6 +353,14 @@ groups:
       - Peter Ferguson
       - Michael Martinez
       - Miranda Gorsuch
+  University of California, Davis:
+    contact: Tony Tyson
+    contribution: SIT-Com support
+    members:
+      - Tony Tyson
+      - Craig Lage
+      - Dan Polin
+      - Adam Snyder
   University of California, Santa Cruz:
     contact: Steve Ritz
     contribution: SIT-Com support

--- a/summary.yaml
+++ b/summary.yaml
@@ -361,6 +361,8 @@ groups:
       - Craig Lage
       - Dan Polin
       - Adam Snyder
+      - Erfan Nourbakhsh
+      - Sam Schmidt
   University of California, Santa Cruz:
     contact: Steve Ritz
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds the UC-Davis group.

Rendered version can be previewed [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-update-uc-davis/index.html).