### PR TITLE
Update US/Chile-11 Group

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -173,7 +173,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Michael Wood-Vasey
 
-  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez
+  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop
 
 
 **US/Chile-12:** *Science validation for sky background modeling and low surface brightness science*

--- a/summary.yaml
+++ b/summary.yaml
@@ -235,6 +235,7 @@ groups:
       - Tatiana Acero Cuellar
       - Benjamin Racine
       - Dominique Fouchez
+      - Rob Knop
   US/Chile-12:
     contact: Ian Dell'Antonio
     contribution: Science validation for sky background modeling and low surface brightness science


### PR DESCRIPTION
This PR adds Rob Knop to the contributor list for US/Chile-11.

Rendered version [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-update-US-Chile-11/index.html).