### PR TITLE
Add Audrey Budlong to UW group

### DIFF
--- a/summary.yaml
+++ b/summary.yaml
@@ -346,6 +346,7 @@ groups:
       - Carl Christoffersen
       - Doug Branton
       - Karlo Mrakovcic
+      - Audrey Budlong
   University of Wisconsin-Madison:
     contact: Keith Bechtol
     contribution: SIT-Com support


### PR DESCRIPTION
This PR makes an adjustment to #12 to add Audrey Budlong to summary.yaml file that is used as source of truth when compiling the document.