### PR TITLE
Add Silvia Pietroni to ITA-INA-S23

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -64,7 +64,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Giuseppe Riccio
 
-  Members: Giuseppe Riccio, Stefano Cavuoti, Massimo Brescia
+  Members: Giuseppe Riccio, Stefano Cavuoti, Massimo Brescia, Silvia Pietroni
 
 
 **JAP-JPG-S2:** *TBD*

--- a/summary.yaml
+++ b/summary.yaml
@@ -104,6 +104,7 @@ groups:
       - Giuseppe Riccio
       - Stefano Cavuoti
       - Massimo Brescia
+      - Silvia Pietroni
   JAP-JPG-S2:
     contact: Dr. Yutaka Komiyama
     contribution: TBD


### PR DESCRIPTION
This PR adds Silvia Pietroni to ITA-INA-S23.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-spietroni/index.html).