### PR TITLE
Add Rance Solomon to FRA-INP-S8

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -29,7 +29,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Pierre Antilogus
 
-  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci
+  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon
 
 
 **FRA-INP-S9:** *Science validation for object detection, weak lensing, and deblending*

--- a/summary.yaml
+++ b/summary.yaml
@@ -54,6 +54,7 @@ groups:
       - Marine Kuna
       - Johann Cohen-Tanugi
       - Marina Ricci
+      - Rance Solomon
   FRA-INP-S9:
     contact: Cyrille Doux
     contribution: Science validation for object detection, weak lensing, and deblending


### PR DESCRIPTION
This PR adds Rance Solomon to RA-INP-S8.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-rsolomon/index.html).