### PR TITLE
Add Benjamin Levine and Prakruth Adari to US/Chile-16

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -215,7 +215,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Anja von der Linden
 
-  Members: Anja von der Linden, Ian Dell’Antonio, Zacharias Escalante, Shuang Liang, Radhakrishnan Srinivasan, Shenming Fu, Camille Avestruz, Ismael Mendoza, Simona Mei, Peter Melchior, Doug Clowe, Rémy Joseph, Cristobal Sifon
+  Members: Anja von der Linden, Ian Dell’Antonio, Zacharias Escalante, Shuang Liang, Radhakrishnan Srinivasan, Shenming Fu, Camille Avestruz, Ismael Mendoza, Simona Mei, Peter Melchior, Doug Clowe, Rémy Joseph, Cristobal Sifon, Benjamin Levine
 
 
 **US/Chile-17:** *Investigation and mitigation of sensor anomalies for ComCam and LSSTCam detectors using calibration and on-sky data*

--- a/groups.rst
+++ b/groups.rst
@@ -215,7 +215,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Anja von der Linden
 
-  Members: Anja von der Linden, Ian Dell’Antonio, Zacharias Escalante, Shuang Liang, Radhakrishnan Srinivasan, Shenming Fu, Camille Avestruz, Ismael Mendoza, Simona Mei, Peter Melchior, Doug Clowe, Rémy Joseph, Cristobal Sifon, Benjamin Levine
+  Members: Anja von der Linden, Ian Dell’Antonio, Zacharias Escalante, Shuang Liang, Radhakrishnan Srinivasan, Shenming Fu, Camille Avestruz, Ismael Mendoza, Simona Mei, Peter Melchior, Doug Clowe, Rémy Joseph, Cristobal Sifon, Benjamin Levine, Prakruth Adari
 
 
 **US/Chile-17:** *Investigation and mitigation of sensor anomalies for ComCam and LSSTCam detectors using calibration and on-sky data*

--- a/summary.yaml
+++ b/summary.yaml
@@ -309,6 +309,7 @@ groups:
       - Rémy Joseph
       - Cristobal Sifon
       - Benjamin Levine
+      - Prakruth Adari
   US/Chile-17:
     contact: Simona Murgia
     contribution: Investigation and mitigation of sensor anomalies for ComCam and LSSTCam detectors using calibration and on-sky data

--- a/summary.yaml
+++ b/summary.yaml
@@ -308,6 +308,7 @@ groups:
       - Doug Clowe
       - Rémy Joseph
       - Cristobal Sifon
+      - Benjamin Levine
   US/Chile-17:
     contact: Simona Murgia
     contribution: Investigation and mitigation of sensor anomalies for ComCam and LSSTCam detectors using calibration and on-sky data


### PR DESCRIPTION
This PR adds Benjamin Levine and Prakruth Adari to US/Chile-16.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-blevine/index.html).