### PR TITLE
Add Xiangchong Li to US/Chile-04

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -131,7 +131,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Mike Jarvis
 
-  Members: Mike Jarvis, Rachel Mandelbaum, Tianqing Zhang, Claire-Alice Hébert, Sid Mau, Pat Burchat, Josh Meyers, Aaron Roodman, Theo Schutt, Chris Stubbs, Elana Urbach, Eske Pedersen, Brodi Elwood, Dan Weatherill, Arun Kannawadi, Erfan Nourbakhsh
+  Members: Mike Jarvis, Rachel Mandelbaum, Tianqing Zhang, Claire-Alice Hébert, Sid Mau, Pat Burchat, Josh Meyers, Aaron Roodman, Theo Schutt, Chris Stubbs, Elana Urbach, Eske Pedersen, Brodi Elwood, Dan Weatherill, Arun Kannawadi, Erfan Nourbakhsh, Xiangchong Li
 
 
 **US/Chile-05:** *Science validation for weak lensing shear estimation and development of advanced image coaddition methods*

--- a/summary.yaml
+++ b/summary.yaml
@@ -177,6 +177,7 @@ groups:
       - Dan Weatherill
       - Arun Kannawadi
       - Erfan Nourbakhsh
+      - Xiangchong Li
   US/Chile-05:
     contact: Matthew R. Becker
     contribution: Science validation for weak lensing shear estimation and development of advanced image coaddition methods


### PR DESCRIPTION
This PR adds Xiangchong Li to US/Chile-04.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-xli/index.html).