### PR TITLE
Add photometric redshift team

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -45,3 +45,11 @@ with open(outfile, 'w') as writer:
     for key in data["groups"].keys():
         if "University" in key and "US/Chile" not in key:
             writeGroupRST(data, key)
+
+    writer.write('\n\n')
+    writer.write('Ex Officio Contributions\n')
+    writer.write('------------------------\n')
+
+    for key in data["groups"].keys():
+        if key in ["Photometric Redshift Team"]:
+            writeGroupRST(data, key)

--- a/groups.rst
+++ b/groups.rst
@@ -95,6 +95,13 @@ International In-Kind Contribution Program
   Members: Ian Shipsey, Jeff Tseng, Farrukh Azfar, Daniel Weatherill
 
 
+**Photometric Redshift Team:** *Implementation of shortlisted photo-z estimators to support early science*
+
+  Point of Contact: Melissa Graham
+
+  Members: Eric Charles, John Franklin Crenshaw, Melissa DeLucchi, Julia Gschwend, Shahab Joudaki, Bryce Kalmbach, Olivia Lynn, Alex Malz, Drew Oldag, Markus Rau, Sam Schmidt, Ignacio Sevilla Noarbe
+
+
 US/Chile Community Engagement with Rubin Observatory Commissioning Effort Program
 ---------------------------------------------------------------------------------
 
@@ -262,3 +269,14 @@ Institutional Contributions to Rubin Observatory Construction
   Point of Contact: Steve Ritz
 
   Members: Steve Ritz, Adrian Shestakov, Duncan Wood
+
+
+Ex Officio Contributions
+------------------------
+
+
+**Photometric Redshift Team:** *Implementation of shortlisted photo-z estimators to support early science*
+
+  Point of Contact: Melissa Graham
+
+  Members: Eric Charles, John Franklin Crenshaw, Melissa DeLucchi, Julia Gschwend, Shahab Joudaki, Bryce Kalmbach, Olivia Lynn, Alex Malz, Drew Oldag, Markus Rau, Sam Schmidt, Ignacio Sevilla Noarbe

--- a/index.rst
+++ b/index.rst
@@ -36,8 +36,10 @@ The focus of the commissioning effort is on demonstrating operational readiness 
 
 All members of the SIT-Com team are expected to follow the `professional standards of conduct <https://www.lsst.org/scientists/codes-of-conduct>`__ adopted by the Project.
 
-The final section of this document lists several additional institutional contributions to Rubin Observatory construction based on agreements that were established prior to the formalization of the two programs mentioned above.
+Section 3.3 of this document lists several additional institutional contributions to Rubin Observatory construction based on agreements that were established prior to the formalization of the two programs mentioned above.
 These university-based groups are making contributions that are partially supported by external sources and are listed in this document together with other in-kind contributions for completeness.
+
+Section 3.4 of this document lists the ex officio members of the Commissioning Team, as described in Section 3.2 of the `Announcement of Opportunity <https://sitcomtn-010.lsst.io/>`__.
 
 Contributing Groups
 ===================

--- a/summary.yaml
+++ b/summary.yaml
@@ -374,3 +374,19 @@ groups:
       - Steve Ritz
       - Adrian Shestakov
       - Duncan Wood
+  Photometric Redshift Team:
+    contact: Melissa Graham
+    contribution: Implementation of shortlisted photo-z estimators to support early science
+    members:
+      - Eric Charles
+      - John Franklin Crenshaw
+      - Melissa DeLucchi
+      - Julia Gschwend
+      - Shahab Joudaki
+      - Bryce Kalmbach
+      - Olivia Lynn
+      - Alex Malz
+      - Drew Oldag
+      - Markus Rau
+      - Sam Schmidt
+      - Ignacio Sevilla Noarbe


### PR DESCRIPTION
This PR adds the photometric redshift team as an ex officio contribution.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-photoz/index.html).

See [A Roadmap to Photometric Redshifts for the LSST Object Catalog ](https://dmtn-049.lsst.io/) for further context.