### PR TITLE
Update JAP-JPG-S2

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -71,7 +71,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Yousuke Utsumi
 
-  Members: Yousuke Utsumi, Yasuda Naoki
+  Members: Yousuke Utsumi, Naoki Yasuda
 
 
 **KOR-KAS-S1:** *KASI Fellows for commissioning observing support*

--- a/groups.rst
+++ b/groups.rst
@@ -67,11 +67,11 @@ International In-Kind Contribution Program
   Members: Giuseppe Riccio, Stefano Cavuoti, Massimo Brescia, Silvia Pietroni
 
 
-**JAP-JPG-S2:** *TBD*
+**JAP-JPG-S2:** *Commissioning support in Chile and data analysis*
 
-  Point of Contact: Dr. Yutaka Komiyama
+  Point of Contact: Yousuke Utsumi
 
-  Members: TBD
+  Members: Yousuke Utsumi, Yasuda Naoki
 
 
 **KOR-KAS-S1:** *KASI Fellows for commissioning observing support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -108,10 +108,11 @@ groups:
       - Massimo Brescia
       - Silvia Pietroni
   JAP-JPG-S2:
-    contact: Dr. Yutaka Komiyama
-    contribution: TBD
+    contact: Yousuke Utsumi
+    contribution: Commissioning support in Chile and data analysis
     members:
-      - TBD
+      - Yousuke Utsumi
+      - Yasuda Naoki
   KOR-KAS-S1:
     contact: Narae Hwang
     contribution: KASI Fellows for commissioning observing support

--- a/summary.yaml
+++ b/summary.yaml
@@ -112,7 +112,7 @@ groups:
     contribution: Commissioning support in Chile and data analysis
     members:
       - Yousuke Utsumi
-      - Yasuda Naoki
+      - Naoki Yasuda
   KOR-KAS-S1:
     contact: Narae Hwang
     contribution: KASI Fellows for commissioning observing support


### PR DESCRIPTION
This PR updates JAP-JPG-S2.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-update-JAP-JPG-S2/index.html).