### PR TITLE
Add Bekah Polen and Michael Troxel to Duke University

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -233,7 +233,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Walter
 
-  Members: Chris Walter
+  Members: Chris Walter, Bekah Polen, Michael Troxel
 
 
 **Harvard University:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -325,6 +325,8 @@ groups:
     contribution: SIT-Com support
     members:
       - Chris Walter
+      - Bekah Polen
+      - Michael Troxel
   Harvard University:
     contact: Chris Stubbs
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Bekah Polen and Michael Troxel to Duke University.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-duke/index.html).