### PR TITLE
Add Laura Toribio to ESP-BCM-S2

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -8,7 +8,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Ignacio Sevilla-Noarbe
 
-  Members: Ignacio Sevilla, Cristobal Padilla, Otger Ballester, Jordi Arellano, Ricard Casas, Cristóbal Pío
+  Members: Ignacio Sevilla, Cristobal Padilla, Otger Ballester, Jordi Arellano, Ricard Casas, Cristóbal Pío, Laura Toribio
 
 
 **FRA-INP-S6:** *Calibration hardware (CBP, flat screen, dome illumination, etc.)*

--- a/summary.yaml
+++ b/summary.yaml
@@ -12,6 +12,7 @@ groups:
       - Jordi Arellano
       - Ricard Casas
       - Cristóbal Pío
+      - Laura Toribio
   FRA-INP-S6:
     contact: Jérémy Neveu
     contribution: Calibration hardware (CBP, flat screen, dome illumination, etc.)


### PR DESCRIPTION
This PR adds Laura Toribio to ESP-BCM-S2.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-ltoribio/index.html).