### PR TITLE
Add Behnood Bandi to UKD-UKD-S13

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -85,7 +85,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Graham Smith
 
-  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt
+  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt, Behnood Bandi
 
 
 **UKD-UKD-S7:** *Science validation for sensor characterization and PSF modelling*

--- a/summary.yaml
+++ b/summary.yaml
@@ -137,6 +137,7 @@ groups:
       - Raphael Shirley
       - Nicholas Walton
       - Boris Leistedt
+      - Behnood Bandi
   UKD-UKD-S7:
     contact: Ian Shipsey
     contribution: Science validation for sensor characterization and PSF modelling


### PR DESCRIPTION
This PR adds Behnood Bandi to UKD-UKD-S13.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-bbandi/index.html).