### PR TITLE
Add Larom Segev to Harvard

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Stubbs
 
-  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu
+  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev
 
 
 **University of Washington:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -348,6 +348,7 @@ groups:
       - Dillon Brout
       - Ali Kurmus
       - Aris Zhu
+      - Larom Segev
   University of Washington:
     contact: Andy Connolly
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Larom Segev to Harvard.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-lsegev/index.html).