### PR TITLE
Add Easton Honaker to US/Chile-08

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -159,7 +159,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Dave Monet
 
-  Members: Dave Monet, Mike Rich, John Gizis, Markus Rabus
+  Members: Dave Monet, Mike Rich, John Gizis, Markus Rabus, Easton Honaker
 
 
 **US/Chile-09:** *Science validation for strong gravitational lensing and active optics system commissioning*

--- a/summary.yaml
+++ b/summary.yaml
@@ -221,6 +221,7 @@ groups:
       - Mike Rich
       - John Gizis
       - Markus Rabus
+      - Easton Honaker
   US/Chile-09:
     contact: Simon Birrer
     contribution: Science validation for strong gravitational lensing and active optics system commissioning


### PR DESCRIPTION
This PR adds Easton Honaker to US/Chile-08.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-ehonaker/index.html).