### PR TITLE
Add Ricardo Sanchez to ITA-INA-S22

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -57,7 +57,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Giuliana Fiorentino
 
-  Members: Rodolfo Canestrari, Gabriele Rodeghiero, Enrico Giro, Marcella Di Criscienzo, Giuliana Fiorentino, Davide Massari, Luciano Lanteri, Salvatore Savarese, Pietro Schipani, Vincenzo Ripepi, Filippo D'Ammando, Vincenzo Testa, Laura Schreiber, Vittorio Braga
+  Members: Rodolfo Canestrari, Gabriele Rodeghiero, Enrico Giro, Marcella Di Criscienzo, Giuliana Fiorentino, Davide Massari, Luciano Lanteri, Salvatore Savarese, Pietro Schipani, Vincenzo Ripepi, Filippo D'Ammando, Vincenzo Testa, Laura Schreiber, Vittorio Braga, Ricardo Sanchez
 
 
 **ITA-INA-S23:** *Instrument, telemetry, and science trend analysis and statistical characterization*

--- a/summary.yaml
+++ b/summary.yaml
@@ -99,6 +99,7 @@ groups:
       - Vincenzo Testa
       - Laura Schreiber
       - Vittorio Braga
+      - Ricardo Sanchez
   ITA-INA-S23:
     contact: Giuseppe Riccio
     contribution: Instrument, telemetry, and science trend analysis and statistical characterization


### PR DESCRIPTION
This PR adds Ricardo Sanchez to ITA-INA-S22.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-rsanchez/index.html).