### PR TITLE
Add Michelle Lin to Harvard

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Stubbs
 
-  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev
+  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin
 
 
 **University of Washington:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -351,6 +351,7 @@ groups:
       - Ali Kurmus
       - Aris Zhu
       - Larom Segev
+      - Michelle Lin
   University of Washington:
     contact: Andy Connolly
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Michelle Lin to Harvard.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-mlin/index.html).