### PR TITLE
Add Doug Yang to Harvard

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Stubbs
 
-  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin
+  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin, Doug Yang
 
 
 **University of Washington:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -353,6 +353,7 @@ groups:
       - Aris Zhu
       - Larom Segev
       - Michelle Lin
+      - Doug Yang
   University of Washington:
     contact: Andy Connolly
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Doug Yang to Harvard.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-dyang/index.html).