### PR TITLE
Add Robert Hynes to US/Chile-11

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -180,7 +180,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Michael Wood-Vasey
 
-  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy
+  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy, Robert Hynes
 
 
 **US/Chile-12:** *Science validation for sky background modeling and low surface brightness science*

--- a/summary.yaml
+++ b/summary.yaml
@@ -258,6 +258,7 @@ groups:
       - Dominique Fouchez
       - Rob Knop
       - Maya Guy
+      - Robert Hynes
   US/Chile-12:
     contact: Ian Dell'Antonio
     contribution: Science validation for sky background modeling and low surface brightness science


### PR DESCRIPTION
This PR adds Robert Hynes to US/Chile-11.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-rhynes/index.html).