### PR TITLE
Add Corentin Ravoux and Yassine Faris to FRA-INP-S8

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -29,7 +29,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Pierre Antilogus
 
-  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer
+  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer, Corentin Ravoux, Yassine Faris
 
 
 **FRA-INP-S9:** *Science validation for object detection, weak lensing, and deblending*

--- a/summary.yaml
+++ b/summary.yaml
@@ -60,6 +60,8 @@ groups:
       - Andrea Jeremie
       - Nathan Amouroux
       - Kelian Sommer
+      - Corentin Ravoux
+      - Yassine Faris
   FRA-INP-S9:
     contact: Cyrille Doux
     contribution: Science validation for object detection, weak lensing, and deblending


### PR DESCRIPTION
This PR adds Corentin Ravoux and Yassine Faris to FRA-INP-S8.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-cravoux_yfaris/index.html).