### PR TITLE
Add Kane Sjoberg and Meghan Marangola to Harvard

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Stubbs
 
-  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin, Doug Yang
+  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin, Doug Yang, Kane Sjoberg
 
 
 **University of Washington:** *SIT-Com support*

--- a/groups.rst
+++ b/groups.rst
@@ -240,7 +240,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Chris Stubbs
 
-  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin, Doug Yang, Kane Sjoberg
+  Members: Chris Stubbs, Elana Urbach, Eske Pedersen, Dillon Brout, Ali Kurmus, Aris Zhu, Larom Segev, Michelle Lin, Doug Yang, Kane Sjoberg, Meghan Marangola
 
 
 **University of Washington:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -366,6 +366,7 @@ groups:
       - Michelle Lin
       - Doug Yang
       - Kane Sjoberg
+      - Meghan Marangola
   University of Washington:
     contact: Andy Connolly
     contribution: SIT-Com support

--- a/summary.yaml
+++ b/summary.yaml
@@ -365,6 +365,7 @@ groups:
       - Larom Segev
       - Michelle Lin
       - Doug Yang
+      - Kane Sjoberg
   University of Washington:
     contact: Andy Connolly
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Kane Sjoberg and Meghan Marangola to Harvard.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-ksjoberg/index.html).