### PR TITLE
Add Xiangyu Huang to US/Chile-09

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -159,7 +159,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Simon Birrer
 
-  Members: Simon Birrer, Paul Schechter, Tansu Daylan
+  Members: Simon Birrer, Paul Schechter, Tansu Daylan, Xiangyu Huang
 
 
 **US/Chile-10:** *Observing support and science validation of time series photometry*

--- a/summary.yaml
+++ b/summary.yaml
@@ -235,6 +235,7 @@ groups:
       - Simon Birrer
       - Paul Schechter
       - Tansu Daylan
+      - Xiangyu Huang
   US/Chile-10:
     contact: Markus Rabus
     contribution: Observing support and science validation of time series photometry


### PR DESCRIPTION
This PR adds Xiangyu Huang to US/Chile-09.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-xhuang/index.html).