### PR TITLE
Add Manon Ramel to FRA-INP-S9

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -36,7 +36,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Cyrille Doux
 
-  Members: Eric Aubourg, Cécile Roucelle, Alexandre Boucaud, Justine Zeghal, Biswajit Biswas, Axel Guinot, Marina Ricci
+  Members: Eric Aubourg, Cécile Roucelle, Alexandre Boucaud, Justine Zeghal, Biswajit Biswas, Axel Guinot, Marina Ricci, Manon Ramel
 
 
 **FRA-INP-S10:** *Camera hardware optimization*

--- a/summary.yaml
+++ b/summary.yaml
@@ -73,6 +73,7 @@ groups:
       - Biswajit Biswas
       - Axel Guinot
       - Marina Ricci
+      - Manon Ramel
   FRA-INP-S10:
     contact: Alexandre Boucaud
     contribution: Camera hardware optimization


### PR DESCRIPTION
This PR adds Manon Ramel to FRA-INP-S9.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-mramel/index.html).