### PR TITLE
Add Martin Millon to US/Chile-11

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -180,7 +180,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Michael Wood-Vasey
 
-  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy, Robert Hynes, Masao Sako, Aditya Inada Somasundaram, Jillian Paulin, Cole Meldorf
+  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy, Robert Hynes, Masao Sako, Aditya Inada Somasundaram, Jillian Paulin, Cole Meldorf, Martin Millon
 
 
 **US/Chile-12:** *Science validation for sky background modeling and low surface brightness science*

--- a/summary.yaml
+++ b/summary.yaml
@@ -273,6 +273,7 @@ groups:
       - Aditya Inada Somasundaram
       - Jillian Paulin
       - Cole Meldorf
+      - Martin Millon
   US/Chile-12:
     contact: Ian Dell'Antonio
     contribution: Science validation for sky background modeling and low surface brightness science


### PR DESCRIPTION
This PR adds Martin Millon to US/Chile-11.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-mmillon/index.html).