### PR TITLE
Add Poshak Gandhi to UKD-UKD-S13

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -85,7 +85,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Graham Smith
 
-  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt, Behnood Bandi
+  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt, Behnood Bandi, Poshak Gandhi
 
 
 **UKD-UKD-S7:** *Science validation for sensor characterization and PSF modelling*

--- a/summary.yaml
+++ b/summary.yaml
@@ -144,6 +144,7 @@ groups:
       - Nicholas Walton
       - Boris Leistedt
       - Behnood Bandi
+      - Poshak Gandhi
   UKD-UKD-S7:
     contact: Ian Shipsey
     contribution: Science validation for sensor characterization and PSF modelling


### PR DESCRIPTION
This PR adds Poshak Gandhi to UKD-UKD-S13.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-pgandhi/index.html).