### PR TITLE
Add Thierry Souverin to FRA-INP-S6

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -15,7 +15,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Jérémy Neveu
 
-  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont
+  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin
 
 
 **FRA-INP-S7:** *AuxTel support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -21,6 +21,7 @@ groups:
       - Laurent Le Guillou
       - Eduardo Sepulveda
       - Sylvain Baumont
+      - Thierry Souverin
   FRA-INP-S7:
     contact: Marc Moniez
     contribution: AuxTel support


### PR DESCRIPTION
This PR adds Thierry Souverin to FRA-INP-S6.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-tsouverin/index.html).