### PR TITLE
Add Tae-Hyeon Shin to US/Chile-05

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -138,7 +138,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Matthew R. Becker
 
-  Members: Matthew R. Becker, Arun Kannawadi, Erin Sheldon, Michael Troxel, David Kirkby, Theo Schutt, Erfan Nourbakhsh, Andy Park
+  Members: Matthew R. Becker, Arun Kannawadi, Erin Sheldon, Michael Troxel, David Kirkby, Theo Schutt, Erfan Nourbakhsh, Andy Park, Tae-Hyeon Shin
 
 
 **US/Chile-06:** *Science validation of galaxy photometry*

--- a/summary.yaml
+++ b/summary.yaml
@@ -218,6 +218,7 @@ groups:
       - Theo Schutt
       - Erfan Nourbakhsh
       - Andy Park
+      - Tae-Hyeon Shin
   US/Chile-06:
     contact: Brant Robertson
     contribution: Science validation of galaxy photometry


### PR DESCRIPTION
This PR adds Tae-Hyeon Shin to US/Chile-05.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-tshin/index.html).