### PR TITLE
Add Kayleigh Excell to UW-Madison

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -261,7 +261,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Keith Bechtol
 
-  Members: Keith Bechtol, Peter Ferguson, Michael Martinez, Miranda Gorsuch
+  Members: Keith Bechtol, Peter Ferguson, Michael Martinez, Miranda Gorsuch, Kayleigh Excell
 
 
 **University of California, Davis:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -415,6 +415,7 @@ groups:
       - Peter Ferguson
       - Michael Martinez
       - Miranda Gorsuch
+      - Kayleigh Excell
   University of California, Davis:
     contact: Tony Tyson
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Kayleigh Excell to UW-Madison.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-kexcell/index.html).