### PR TITLE
Add Enya Van den Abeele to FRA-INP-S6 and FRA-INP-S7

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -15,14 +15,14 @@ International In-Kind Contribution Program
 
   Point of Contact: Jérémy Neveu
 
-  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin
+  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin, Enya Van den Abeele
 
 
 **FRA-INP-S7:** *AuxTel support*
 
   Point of Contact: Marc Moniez
 
-  Members: Marc Moniez, Sylvie Dagoret-Campagne, Martin Monroy, Jérémy Neveu, Laurent Le Guillou, Joseph Chevalier
+  Members: Marc Moniez, Sylvie Dagoret-Campagne, Martin Monroy, Jérémy Neveu, Laurent Le Guillou, Joseph Chevalier, Enya Van den Abeele
 
 
 **FRA-INP-S8:** *Commissioning at pixel level, data quality, and “on-sky” calibration*

--- a/summary.yaml
+++ b/summary.yaml
@@ -22,6 +22,7 @@ groups:
       - Eduardo Sepulveda
       - Sylvain Baumont
       - Thierry Souverin
+      - Enya Van den Abeele
   FRA-INP-S7:
     contact: Marc Moniez
     contribution: AuxTel support
@@ -32,6 +33,7 @@ groups:
       - Jérémy Neveu
       - Laurent Le Guillou
       - Joseph Chevalier
+      - Enya Van den Abeele
   FRA-INP-S8:
      contact: Pierre Antilogus
      contribution: Commissioning at pixel level, data quality, and “on-sky” calibration


### PR DESCRIPTION
This PR adds Enya Van den Abeele to FRA-INP-S6 and FRA-INP-S7.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-van_den_abeele/index.html).