### PR TITLE
Add Andrew Engel to US/Chile-12

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -187,7 +187,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Ian Dell'Antonio
 
-  Members: Ian Dell’Antonio, Jessica Nelson, Zacharias Escalante, Alex Drlica-Wagner, Yao-Yuan Mao, Alexie Leauthaud, Yuanyuan Zhang, Annika Peter, Anja von der Linden, Matt Kwiecien, Tesla Jeltema, Anthony Englert, Jiaxuan Li, Conghao Zhou, Soren Helhoski
+  Members: Ian Dell’Antonio, Jessica Nelson, Zacharias Escalante, Alex Drlica-Wagner, Yao-Yuan Mao, Alexie Leauthaud, Yuanyuan Zhang, Annika Peter, Anja von der Linden, Matt Kwiecien, Tesla Jeltema, Anthony Englert, Jiaxuan Li, Conghao Zhou, Soren Helhoski, Andrew Engel
 
 
 **US/Chile-13:** *Science validation for galaxy clustering analyses*

--- a/summary.yaml
+++ b/summary.yaml
@@ -300,6 +300,7 @@ groups:
       - Jiaxuan Li
       - Conghao Zhou
       - Soren Helhoski
+      - Andrew Engel
   US/Chile-13:
     contact: Eric Gawiser
     contribution: Science validation for galaxy clustering analyses


### PR DESCRIPTION
This PR adds Andrew Engel to US/Chile-12.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-aengel/index.html).