### PR TITLE
Add Alessio Taranto to ITA-INA-S21

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -50,7 +50,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Felice Cusano
 
-  Members: Felice Cusano, Rodolfo Canestrari, Gabriele Rodeghiero, Enrico Giro, Luca Rosignoli
+  Members: Felice Cusano, Rodolfo Canestrari, Gabriele Rodeghiero, Enrico Giro, Luca Rosignoli, Alessio Taranto
 
 
 **ITA-INA-S22:** *Image quality analysis*

--- a/summary.yaml
+++ b/summary.yaml
@@ -96,6 +96,7 @@ groups:
       - Gabriele Rodeghiero
       - Enrico Giro
       - Luca Rosignoli
+      - Alessio Taranto
   ITA-INA-S22:
     contact: Giuliana Fiorentino
     contribution: Image quality analysis


### PR DESCRIPTION
This PR adds Alessio Taranto to ITA-INA-S21.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-ataranto/index.html).