### PR TITLE
Add Julian Beas-Gonzalez to UW-Madison

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -268,7 +268,7 @@ Institutional Contributions to Rubin Observatory Construction
 
   Point of Contact: Keith Bechtol
 
-  Members: Keith Bechtol, Peter Ferguson, Michael Martinez, Miranda Gorsuch, Kayleigh Excell
+  Members: Keith Bechtol, Peter Ferguson, Michael Martinez, Miranda Gorsuch, Kayleigh Excell, Julian Beas-Gonzalez
 
 
 **University of California, Davis:** *SIT-Com support*

--- a/summary.yaml
+++ b/summary.yaml
@@ -446,6 +446,7 @@ groups:
       - Michael Martinez
       - Miranda Gorsuch
       - Kayleigh Excell
+      - Julian Beas-Gonzalez
   University of California, Davis:
     contact: Tony Tyson
     contribution: SIT-Com support


### PR DESCRIPTION
This PR adds Julian Beas-Gonzalez to UW-Madison.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-jbeas-gonzalez/index.html).