### PR TITLE
Update FRA-INP for Dec 2024

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -15,7 +15,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Jérémy Neveu
 
-  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin, Enya Van den Abeele
+  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin, Enya Van den Abeele, Nathan Amouroux, Johan Bregeon
 
 
 **FRA-INP-S7:** *AuxTel support*
@@ -29,7 +29,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Pierre Antilogus
 
-  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer, Corentin Ravoux, Yassine Faris, Cyrille Rosset, Didier Verkindt, Antoine Bernard, Eduardo Barroso
+  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer, Corentin Ravoux, Yassine Faris, Cyrille Rosset, Didier Verkindt, Antoine Bernard, Eduardo Barroso, Narei Lorenzo-Martinez, Vincent Reverdy, Tania Regimbau, Yves Zolnierowski, Marina Masson
 
 
 **FRA-INP-S9:** *Science validation for object detection, weak lensing, and deblending*

--- a/summary.yaml
+++ b/summary.yaml
@@ -23,6 +23,8 @@ groups:
       - Sylvain Baumont
       - Thierry Souverin
       - Enya Van den Abeele
+      - Nathan Amouroux
+      - Johan Bregeon
   FRA-INP-S7:
     contact: Marc Moniez
     contribution: AuxTel support
@@ -69,6 +71,11 @@ groups:
       - Didier Verkindt
       - Antoine Bernard
       - Eduardo Barroso
+      - Narei Lorenzo-Martinez
+      - Vincent Reverdy
+      - Tania Regimbau
+      - Yves Zolnierowski
+      - Marina Masson
   FRA-INP-S9:
     contact: Cyrille Doux
     contribution: Science validation for object detection, weak lensing, and deblending


### PR DESCRIPTION
This PR adds several commissioners.

FRA-INP-S6:
- Nathan Amouroux
- Johan Bregeon

FRA-INP-S8:
- Narei Lorenzo-Martinez
- Vincent Reverdy
- Tania Regimbau
- Yves Zolnierowski
- Marina Masson

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-fra-inp_dec_2024/index.html).