### PR TITLE
Add Jaemyoung (Jason) Lee to US/Chile-11

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -187,7 +187,7 @@ US/Chile Community Engagement with Rubin Observatory Commissioning Effort Progra
 
   Point of Contact: Michael Wood-Vasey
 
-  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy, Robert Hynes, Masao Sako, Aditya Inada Somasundaram, Jillian Paulin, Cole Meldorf, Martin Millon, Shreya Anand
+  Members: Michael Wood-Vasey, Shu Liu, Bruno Sánchez, Gautham Narayan, Amanda Wasserman, Rick Kessler, Bob Armstrong, Saurabh Jha, Federica Bianco, Tatiana Acero Cuellar, Benjamin Racine, Dominique Fouchez, Rob Knop, Maya Guy, Robert Hynes, Masao Sako, Aditya Inada Somasundaram, Jillian Paulin, Cole Meldorf, Martin Millon, Shreya Anand, Jaemyoung (Jason) Lee
 
 
 **US/Chile-12:** *Science validation for sky background modeling and low surface brightness science*

--- a/summary.yaml
+++ b/summary.yaml
@@ -308,6 +308,7 @@ groups:
       - Cole Meldorf
       - Martin Millon
       - Shreya Anand
+      - Jaemyoung (Jason) Lee
   US/Chile-12:
     contact: Ian Dell'Antonio
     contribution: Science validation for sky background modeling and low surface brightness science


### PR DESCRIPTION
This PR adds Jaemyoung (Jason) Lee to US/Chile-11.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-bechtol-jlee/index.html).