### PR TITLE
Update FRA-INP-S6, S8 and S9

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -15,7 +15,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Jérémy Neveu
 
-  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin, Enya Van den Abeele, Nathan Amouroux, Johan Bregeon
+  Members: Jérémy Neveu, Laurent Le Guillou, Eduardo Sepulveda, Sylvain Baumont, Thierry Souverin, Enya Van den Abeele, Nathan Amouroux, Johan Bregeon, Angelo Lamure-Fontanini
 
 
 **FRA-INP-S7:** *AuxTel support*
@@ -29,14 +29,14 @@ International In-Kind Contribution Program
 
   Point of Contact: Pierre Antilogus
 
-  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer, Corentin Ravoux, Yassine Faris, Cyrille Rosset, Didier Verkindt, Antoine Bernard, Eduardo Barroso, Narei Lorenzo-Martinez, Vincent Reverdy, Tania Regimbau, Yves Zolnierowski, Marina Masson
+  Members: Dominique Boutigny, Sabine Elles, Thibault Guillemin, Fabio Hernandez, Fabrice Feinstein, Dominique Fouchez, Benjamin Racine, André Tilquin, Emmanuel Gangler, Fabrice Jammes, Nicoleta Pauna, Pierre Antilogus, Pierre Astier, Claire Juramy, Aurélien Barrau, Johan Brégeon, Céline Combet, Marine Kuna, Johann Cohen-Tanugi, Marina Ricci, Rance Solomon, Philippe Gris, Andrea Jeremie, Nathan Amouroux, Kelian Sommer, Corentin Ravoux, Yassine Faris, Cyrille Rosset, Didier Verkindt, Antoine Bernard, Eduardo Barroso, Narei Lorenzo-Martinez, Vincent Reverdy, Tania Regimbau, Yves Zolnierowski, Marina Masson, Dimitri Buffat, Laurent Magri-Stella
 
 
 **FRA-INP-S9:** *Science validation for object detection, weak lensing, and deblending*
 
   Point of Contact: Cyrille Doux
 
-  Members: Cyrille Doux, Eric Aubourg, Cécile Roucelle, Alexandre Boucaud, Justine Zeghal, Biswajit Biswas, Axel Guinot, Marina Ricci, Manon Ramel
+  Members: Cyrille Doux, Eric Aubourg, Cécile Roucelle, Alexandre Boucaud, Justine Zeghal, Biswajit Biswas, Axel Guinot, Marina Ricci, Manon Ramel, Eva Vuilloz
 
 
 **FRA-INP-S10:** *Camera hardware optimization*

--- a/summary.yaml
+++ b/summary.yaml
@@ -25,6 +25,7 @@ groups:
       - Enya Van den Abeele
       - Nathan Amouroux
       - Johan Bregeon
+      - Angelo Lamure-Fontanini
   FRA-INP-S7:
     contact: Marc Moniez
     contribution: AuxTel support
@@ -76,6 +77,8 @@ groups:
       - Tania Regimbau
       - Yves Zolnierowski
       - Marina Masson
+      - Dimitri Buffat
+      - Laurent Magri-Stella
   FRA-INP-S9:
     contact: Cyrille Doux
     contribution: Science validation for object detection, weak lensing, and deblending
@@ -89,6 +92,7 @@ groups:
       - Axel Guinot
       - Marina Ricci
       - Manon Ramel
+      - Eva Vuilloz
   FRA-INP-S10:
     contact: Alexandre Boucaud
     contribution: Camera hardware optimization


### PR DESCRIPTION
This PR adds 

FRA-INP-S6
- IJCLab (J. Neveu) : Angelo Lamure-Fontani

FRA-INP-S8
- LPSC (J. Bregeon) : Dimitri Buffat
- LAPP (V. Reverdy) : Laurent Magri-Stella

FRA-INP-S9
- APC (M. Ricci) : Eva Vuilloz

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-update_fra-inp-s6-s8-s9/index.html).