### PR TITLE
Add Reese Wilkinson to UKD-UKD-S13

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -92,7 +92,7 @@ International In-Kind Contribution Program
 
   Point of Contact: Graham Smith
 
-  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt, Behnood Bandi, Poshak Gandhi, Elham Saremi, Richard McMahon, Manda Banerji, Sugata Kaviraj, Chris Collins, Anupreeta More, Aprajita Verma, Kathy Romer, Paul Giles, Andres Ponte Perez, Suhail Dhawan
+  Members: Aaron Watkins, Jon Loveday, Graham Smith, Tom Wilson, Dan Ryczanowski, Gavin Dalton, Will Sutherland, Tim Naylor, Raphael Shirley, Nicholas Walton, Boris Leistedt, Behnood Bandi, Poshak Gandhi, Elham Saremi, Richard McMahon, Manda Banerji, Sugata Kaviraj, Chris Collins, Anupreeta More, Aprajita Verma, Kathy Romer, Paul Giles, Andres Ponte Perez, Suhail Dhawan, Reese Wilkinson
 
 
 **UKD-UKD-S7:** *Science validation for sensor characterization and PSF modelling*

--- a/summary.yaml
+++ b/summary.yaml
@@ -182,6 +182,7 @@ groups:
       - Paul Giles
       - Andres Ponte Perez
       - Suhail Dhawan
+      - Reese Wilkinson
   UKD-UKD-S7:
     contact: Ian Shipsey
     contribution: Science validation for sensor characterization and PSF modelling


### PR DESCRIPTION
This PR adds Reese Wilkinson to UKD-UKD-S13.

Live draft available [here](https://sitcomtn-050.lsst.io/v/u-kbechtol-rwilkinson/index.html).